### PR TITLE
Add Safe gas estimator for Görli

### DIFF
--- a/src/gnosis_safe.rs
+++ b/src/gnosis_safe.rs
@@ -10,11 +10,13 @@ use std::{convert::TryInto, time::Duration};
 /// The default uris at which the gas station api is available under.
 const DEFAULT_MAINNET_URI: &str = "https://safe-relay.gnosis.io/api/v1/gas-station/";
 const DEFAULT_RINKEBY_URI: &str = "https://safe-relay.rinkeby.gnosis.io/api/v1/gas-station/";
+const DEFAULT_GOERLI_URI: &str = "https://safe-relay.goerli.gnosis.io/api/v1/gas-station/";
 
 pub fn api_url_from_network_id(network_id: &str) -> Option<&'static str> {
     match network_id {
         "1" => Some(DEFAULT_MAINNET_URI),
         "4" => Some(DEFAULT_RINKEBY_URI),
+        "5" => Some(DEFAULT_GOERLI_URI),
         _ => None,
     }
 }
@@ -172,13 +174,14 @@ pub mod tests {
         assert_approx_eq!(estimate.max_fee_per_gas, 300.0);
     }
 
-    // cargo test -p services-core gnosis_safe -- --ignored --nocapture
-    #[tokio::test]
-    #[ignore]
-    async fn real_request() {
-        let gas_station =
-            GnosisSafeGasStation::with_network_id("1", TestTransport::default()).unwrap();
+    async fn real_request(network_id: usize) {
+        let gas_station = GnosisSafeGasStation::with_network_id(
+            &network_id.to_string(),
+            TestTransport::default(),
+        )
+        .unwrap();
         let response = gas_station.gas_prices().await.unwrap();
+        println!("Network ID {}", network_id);
         println!("{:?}", response);
         for i in 0..10 {
             let time_limit = Duration::from_secs(i * 10);
@@ -189,5 +192,24 @@ pub mod tests {
                 price.max_fee_per_gas / 1e9,
             );
         }
+    }
+
+    // cargo test gnosis_safe -- --ignored --nocapture
+    #[tokio::test]
+    #[ignore]
+    async fn real_request_mainnet() {
+        real_request(1).await;
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn real_request_rinkeby() {
+        real_request(4).await;
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn real_request_goerli() {
+        real_request(5).await;
     }
 }


### PR DESCRIPTION
Adds Görli URLs to the Safe gas estimation and related tests.

### Test plan


Look at the output of:

```
cargo test gnosis_safe -- --ignored --nocapture
```

<details><summary>output</summary>

```
running 3 tests
Network ID 5
GasPrices { last_update: "2022-06-30T16:47:49.448491Z", lowest: 8.0, safe_low: 1500000008.0, standard: 1500000009.0, fast: 2000000010.0, fastest: 1000000000001.0 }
gas price estimate for 0 seconds: 4.00000002 gwei
gas price estimate for 10 seconds: 3.000000015 gwei
gas price estimate for 20 seconds: 2.00000001 gwei
gas price estimate for 30 seconds: 1.500000009 gwei
gas price estimate for 40 seconds: 1.5000000085 gwei
gas price estimate for 50 seconds: 1.500000008 gwei
gas price estimate for 60 seconds: 1.486363644290909 gwei
gas price estimate for 70 seconds: 1.4727272805818181 gwei
gas price estimate for 80 seconds: 1.4590909168727273 gwei
gas price estimate for 90 seconds: 1.4454545531636365 gwei
Network ID 1
GasPrices { last_update: "2022-06-30T16:51:45.017881Z", lowest: 32370117918.0, safe_low: 46664944398.0, standard: 53315026082.0, fast: 67429166028.0, fastest: 8548829669843.0 }
gas price estimate for 0 seconds: 134.858332056 gwei
gas price estimate for 10 seconds: 101.143749042 gwei
gas price estimate for 20 seconds: 67.429166028 gwei
gas price estimate for 30 seconds: 53.315026082 gwei
gas price estimate for 40 seconds: 49.98998524 gwei
gas price estimate for 50 seconds: 46.664944398 gwei
gas price estimate for 60 seconds: 46.24071763074545 gwei
gas price estimate for 70 seconds: 45.816490863490905 gwei
gas price estimate for 80 seconds: 45.39226409623637 gwei
gas price estimate for 90 seconds: 44.96803732898182 gwei
test gnosis_safe::tests::real_request_goerli ... ok
test gnosis_safe::tests::real_request_mainnet ... ok
Network ID 4
GasPrices { last_update: "2022-06-30T16:49:44.597380Z", lowest: 1000000051.0, safe_low: 1500000372.0, standard: 1750953616.0, fast: 2500000072.0, fastest: 333000099568.0 }
gas price estimate for 0 seconds: 5.000000144 gwei
gas price estimate for 10 seconds: 3.750000108 gwei
gas price estimate for 20 seconds: 2.500000072 gwei
gas price estimate for 30 seconds: 1.750953616 gwei
gas price estimate for 40 seconds: 1.625476994 gwei
gas price estimate for 50 seconds: 1.500000372 gwei
gas price estimate for 60 seconds: 1.4863640049818183 gwei
gas price estimate for 70 seconds: 1.4727276379636365 gwei
gas price estimate for 80 seconds: 1.4590912709454547 gwei
gas price estimate for 90 seconds: 1.4454549039272728 gwei
test gnosis_safe::tests::real_request_rinkeby ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 22 filtered out; finished in 0.07s
```
</details>