### PR TITLE
Make native estimator more robust against node not following spec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ primitive-types = { version = "0.10", features = ["fp-conversion"], optional = t
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_with = "1.6"
-tokio = { version = "1.9", features = ["sync", "time"], optional = true }
+tokio = { version = "1.9", features = ["sync", "time", "rt"], optional = true }
 tracing = "0.1"
 url = "2.0"
 web3 = { version = "0.18", default-features = false, optional = true }


### PR DESCRIPTION
Fixes https://github.com/cowprotocol/gas-estimation/issues/7 .

As explained in the issue this code could panic in some circumstances. With this PR we never panic. Depending on in what way the node violates the spec we log a warning and/or skip the logic that estimates the priority fee from previous block. There is already a code path for both (rewards vector is empty).

There were two possible panics both triggered by a node not following the spec:
1. Response is missing the `reward` field. In the original JS code this would implicitly throw an exception. In the Rust code before this PR this would return early with a partial result and now returns an error which we log and then continue with the fallback priority fee.
2. reward field doesn't contain right number of responses. In the original JS code this would implicitly throw an exception. In the Rust code before this PR this would panic. I converted this code to be iterator based so that it doesn't panic. I was thinking about also detecting this condition and erroring out but we can just continue with the algorithm as usual without a problem as the function is only interested in all of the reward fields it collects and doesn't care about their indexes or orderings.